### PR TITLE
Make it compatible with latest ROOT >= 6.22

### DIFF
--- a/bin/hepmc2root.py
+++ b/bin/hepmc2root.py
@@ -167,7 +167,7 @@ class hepmc2root:
                 field = name
                 fmt   = '%s/%s' % (field, T)
             self.branch.append(self.tree.Branch(field,
-                                                ROOT.AddressOf(self.bag, field),
+                                                ROOT.addressof(self.bag, field),
                                                     fmt))
         # list branches
         


### PR DESCRIPTION
`AddressOf` has changed to `addressof` in newer versions of pyroot